### PR TITLE
fix test script error by using Math.toDegrees()

### DIFF
--- a/test/simplejavacalculatorTest/CalculatorTest.java
+++ b/test/simplejavacalculatorTest/CalculatorTest.java
@@ -79,24 +79,23 @@ public class CalculatorTest {
 		Assertions.assertEquals(0.10, calculator.calculateMono(Calculator.MonoOperatorModes.oneDividedBy, 10.0));
 	}
 	
-//	@Test
-//	public void CalculateMonoSinTest() {
-//		Calculator calculator = new Calculator();
-//		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.sin, java.lang.Math.PI / 6), 0.0000000001);
-//	}
-//	
-//	@Test
-//	public void CalculateMonoCosTest() {
-//		Calculator calculator = new Calculator();
-//		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.cos, java.lang.Math.PI / 3), 0.0000000001);
-//	}
-//	
-//	@Test
-//	public void CalculateMonoTanTest() {
-//		Calculator calculator = new Calculator();
-//		Assertions.assertEquals(1.0, calculator.calculateMono(Calculator.MonoOperatorModes.tan, java.lang.Math.PI / 4), 0.0000000001);
-//	}
+	@Test
+	void CalculateMonoSinTest() {
+		Calculator calculator = new Calculator();
+		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.sin, Math.toDegrees(java.lang.Math.PI) / 6), 0.0000000001);
+	}
 	
+	@Test
+	void CalculateMonoCosTest() {
+		Calculator calculator = new Calculator();
+		Assertions.assertEquals(0.5, calculator.calculateMono(Calculator.MonoOperatorModes.cos, Math.toDegrees(java.lang.Math.PI) / 3), 0.0000000001);
+	}
+	
+	@Test
+	void CalculateMonoTanTest() {
+		Calculator calculator = new Calculator();
+		Assertions.assertEquals(1.0, calculator.calculateMono(Calculator.MonoOperatorModes.tan, Math.toDegrees(java.lang.Math.PI) / 4), 0.0000000001);
+	}
 	
 	@Test
 	public void CalculateMonoLogTest() {


### PR DESCRIPTION
Math.toDegrees() function is applied to the function tests CalculateMonoSinTest(), CalculateMonoCosTest() and CalculateMonoTanTest(), so the calculation is corrected.